### PR TITLE
update to typings 1.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "tslint": "tslint src/**/*.ts",
     "test": "npm run build && mocha lib/**/*.spec.js",
     "build": "tsc -p .",
-    "api": "typedoc -p . --rootDir src --out public/docs --module commonjs --stripInternal --name Relution-SDK --exclude **/*.spec.ts src typings/main.d.ts",
+    "api": "typedoc -p . --rootDir src --out public/docs --module commonjs --stripInternal --name Relution-SDK --exclude **/*.spec.ts src typings/index.d.ts",
     "watch": "tsc -p . -w",
     "postinstall": "typings install",
 	"browserify": "browserify index.js -o browser.js"

--- a/public/docs/interfaces/_web_http_.httpoptions.html
+++ b/public/docs/interfaces/_web_http_.httpoptions.html
@@ -163,7 +163,7 @@
 						<p>Inherited from CoreOptions.agentClass</p>
 						<p>Overwrites <a href="_core_init_.httpagentoptions.html">HttpAgentOptions</a>.<a href="_core_init_.httpagentoptions.html#agentclass">agentClass</a></p>
 						<ul>
-							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/main/definitions/request/index.d.ts:126</li>
+							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/modules/request/index.d.ts:126</li>
 						</ul>
 					</aside>
 				</section>
@@ -175,7 +175,7 @@
 						<p>Inherited from CoreOptions.agentOptions</p>
 						<p>Overwrites <a href="_core_init_.httpagentoptions.html">HttpAgentOptions</a>.<a href="_core_init_.httpagentoptions.html#agentoptions">agentOptions</a></p>
 						<ul>
-							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/main/definitions/request/index.d.ts:125</li>
+							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/modules/request/index.d.ts:125</li>
 						</ul>
 					</aside>
 				</section>
@@ -205,7 +205,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CoreOptions.auth</p>
 						<ul>
-							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/main/definitions/request/index.d.ts:118</li>
+							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/modules/request/index.d.ts:118</li>
 						</ul>
 					</aside>
 				</section>
@@ -216,7 +216,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CoreOptions.aws</p>
 						<ul>
-							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/main/definitions/request/index.d.ts:120</li>
+							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/modules/request/index.d.ts:120</li>
 						</ul>
 					</aside>
 				</section>
@@ -227,7 +227,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CoreOptions.baseUrl</p>
 						<ul>
-							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/main/definitions/request/index.d.ts:113</li>
+							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/modules/request/index.d.ts:113</li>
 						</ul>
 					</aside>
 				</section>
@@ -238,7 +238,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CoreOptions.body</p>
 						<ul>
-							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/main/definitions/request/index.d.ts:132</li>
+							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/modules/request/index.d.ts:132</li>
 						</ul>
 					</aside>
 				</section>
@@ -249,7 +249,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CoreOptions.ca</p>
 						<ul>
-							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/main/definitions/request/index.d.ts:147</li>
+							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/modules/request/index.d.ts:147</li>
 						</ul>
 					</aside>
 				</section>
@@ -260,7 +260,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CoreOptions.callback</p>
 						<ul>
-							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/main/definitions/request/index.d.ts:114</li>
+							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/modules/request/index.d.ts:114</li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -298,7 +298,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CoreOptions.cert</p>
 						<ul>
-							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/main/definitions/request/index.d.ts:145</li>
+							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/modules/request/index.d.ts:145</li>
 						</ul>
 					</aside>
 				</section>
@@ -343,7 +343,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CoreOptions.encoding</p>
 						<ul>
-							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/main/definitions/request/index.d.ts:136</li>
+							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/modules/request/index.d.ts:136</li>
 						</ul>
 					</aside>
 				</section>
@@ -354,7 +354,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CoreOptions.followAllRedirects</p>
 						<ul>
-							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/main/definitions/request/index.d.ts:134</li>
+							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/modules/request/index.d.ts:134</li>
 						</ul>
 					</aside>
 				</section>
@@ -365,7 +365,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CoreOptions.followRedirect</p>
 						<ul>
-							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/main/definitions/request/index.d.ts:133</li>
+							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/modules/request/index.d.ts:133</li>
 						</ul>
 					</aside>
 				</section>
@@ -376,7 +376,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CoreOptions.forever</p>
 						<ul>
-							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/main/definitions/request/index.d.ts:127</li>
+							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/modules/request/index.d.ts:127</li>
 						</ul>
 					</aside>
 				</section>
@@ -387,7 +387,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CoreOptions.form</p>
 						<ul>
-							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/main/definitions/request/index.d.ts:117</li>
+							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/modules/request/index.d.ts:117</li>
 						</ul>
 					</aside>
 				</section>
@@ -398,7 +398,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CoreOptions.formData</p>
 						<ul>
-							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/main/definitions/request/index.d.ts:116</li>
+							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/modules/request/index.d.ts:116</li>
 						</ul>
 					</aside>
 				</section>
@@ -409,7 +409,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CoreOptions.gzip</p>
 						<ul>
-							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/main/definitions/request/index.d.ts:141</li>
+							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/modules/request/index.d.ts:141</li>
 						</ul>
 					</aside>
 				</section>
@@ -420,7 +420,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CoreOptions.har</p>
 						<ul>
-							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/main/definitions/request/index.d.ts:148</li>
+							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/modules/request/index.d.ts:148</li>
 						</ul>
 					</aside>
 				</section>
@@ -431,7 +431,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CoreOptions.hawk</p>
 						<ul>
-							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/main/definitions/request/index.d.ts:121</li>
+							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/modules/request/index.d.ts:121</li>
 						</ul>
 					</aside>
 				</section>
@@ -442,7 +442,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CoreOptions.headers</p>
 						<ul>
-							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/main/definitions/request/index.d.ts:131</li>
+							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/modules/request/index.d.ts:131</li>
 						</ul>
 					</aside>
 				</section>
@@ -453,7 +453,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CoreOptions.host</p>
 						<ul>
-							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/main/definitions/request/index.d.ts:128</li>
+							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/modules/request/index.d.ts:128</li>
 						</ul>
 					</aside>
 				</section>
@@ -464,7 +464,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CoreOptions.jar</p>
 						<ul>
-							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/main/definitions/request/index.d.ts:115</li>
+							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/modules/request/index.d.ts:115</li>
 						</ul>
 					</aside>
 				</section>
@@ -475,7 +475,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CoreOptions.json</p>
 						<ul>
-							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/main/definitions/request/index.d.ts:123</li>
+							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/modules/request/index.d.ts:123</li>
 						</ul>
 					</aside>
 				</section>
@@ -486,7 +486,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CoreOptions.key</p>
 						<ul>
-							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/main/definitions/request/index.d.ts:144</li>
+							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/modules/request/index.d.ts:144</li>
 						</ul>
 					</aside>
 				</section>
@@ -517,7 +517,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CoreOptions.maxRedirects</p>
 						<ul>
-							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/main/definitions/request/index.d.ts:135</li>
+							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/modules/request/index.d.ts:135</li>
 						</ul>
 					</aside>
 				</section>
@@ -528,7 +528,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CoreOptions.method</p>
 						<ul>
-							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/main/definitions/request/index.d.ts:130</li>
+							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/modules/request/index.d.ts:130</li>
 						</ul>
 					</aside>
 				</section>
@@ -539,7 +539,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CoreOptions.multipart</p>
 						<ul>
-							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/main/definitions/request/index.d.ts:124</li>
+							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/modules/request/index.d.ts:124</li>
 						</ul>
 					</aside>
 				</section>
@@ -550,7 +550,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CoreOptions.oauth</p>
 						<ul>
-							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/main/definitions/request/index.d.ts:119</li>
+							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/modules/request/index.d.ts:119</li>
 						</ul>
 					</aside>
 				</section>
@@ -561,7 +561,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CoreOptions.passphrase</p>
 						<ul>
-							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/main/definitions/request/index.d.ts:146</li>
+							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/modules/request/index.d.ts:146</li>
 						</ul>
 					</aside>
 				</section>
@@ -572,7 +572,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CoreOptions.pool</p>
 						<ul>
-							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/main/definitions/request/index.d.ts:137</li>
+							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/modules/request/index.d.ts:137</li>
 						</ul>
 					</aside>
 				</section>
@@ -583,7 +583,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CoreOptions.port</p>
 						<ul>
-							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/main/definitions/request/index.d.ts:129</li>
+							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/modules/request/index.d.ts:129</li>
 						</ul>
 					</aside>
 				</section>
@@ -594,7 +594,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CoreOptions.postambleCRLF</p>
 						<ul>
-							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/main/definitions/request/index.d.ts:143</li>
+							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/modules/request/index.d.ts:143</li>
 						</ul>
 					</aside>
 				</section>
@@ -605,7 +605,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CoreOptions.preambleCRLF</p>
 						<ul>
-							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/main/definitions/request/index.d.ts:142</li>
+							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/modules/request/index.d.ts:142</li>
 						</ul>
 					</aside>
 				</section>
@@ -616,7 +616,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CoreOptions.proxy</p>
 						<ul>
-							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/main/definitions/request/index.d.ts:139</li>
+							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/modules/request/index.d.ts:139</li>
 						</ul>
 					</aside>
 				</section>
@@ -627,7 +627,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CoreOptions.qs</p>
 						<ul>
-							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/main/definitions/request/index.d.ts:122</li>
+							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/modules/request/index.d.ts:122</li>
 						</ul>
 					</aside>
 				</section>
@@ -672,7 +672,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CoreOptions.strictSSL</p>
 						<ul>
-							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/main/definitions/request/index.d.ts:140</li>
+							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/modules/request/index.d.ts:140</li>
 						</ul>
 					</aside>
 				</section>
@@ -707,7 +707,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CoreOptions.timeout</p>
 						<ul>
-							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/main/definitions/request/index.d.ts:138</li>
+							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/modules/request/index.d.ts:138</li>
 						</ul>
 					</aside>
 				</section>
@@ -718,7 +718,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from UrlOptions.url</p>
 						<ul>
-							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/main/definitions/request/index.d.ts:156</li>
+							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/modules/request/index.d.ts:156</li>
 						</ul>
 					</aside>
 				</section>
@@ -729,7 +729,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from CoreOptions.useQuerystring</p>
 						<ul>
-							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/main/definitions/request/index.d.ts:149</li>
+							<li>Defined in D:/gofer-core/gofer-workspace/relution-sdk/typings/modules/request/index.d.ts:149</li>
 						</ul>
 					</aside>
 				</section>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,10 +17,10 @@
     "filesGlob": [
         "src/**/*.ts",
         "!src/**/*.d.ts",
-        "typings/main.d.ts"
+        "typings/index.d.ts"
     ],
     "files": [
-        "typings/main.d.ts",
+        "typings/index.d.ts",
         "src/connector/connector.ts",
         "src/connector/index.ts",
         "src/core/diag.spec.ts",

--- a/typings.json
+++ b/typings.json
@@ -4,7 +4,7 @@
   "devDependencies": {
     "sinon": "registry:npm/sinon#1.16.0+20160309002336"
   },
-  "ambientDependencies": {
+  "globalDependencies": {
     "mocha": "registry:dt/mocha#2.2.5+20160317120654",
     "node": "registry:dt/node#4.0.0+20160423143914",
     "q": "registry:dt/q#0.0.0+20160417152954"


### PR DESCRIPTION
Using typings 1.0.4 instead of 0.8... instead, same changes as for relution-cli.