### PR TITLE
new syntax for specifying prototype properties

### DIFF
--- a/src/livedata/Collection.spec.ts
+++ b/src/livedata/Collection.spec.ts
@@ -91,7 +91,7 @@ describe(module.filename || __filename, function() {
 
       class Developer extends Model.defaults({
         idAttribute: '_id',
-        entity = 'Developer'
+        entity: 'Developer'
       }) {}
       TEST.Developer = Developer;
 

--- a/src/livedata/Collection.spec.ts
+++ b/src/livedata/Collection.spec.ts
@@ -89,16 +89,18 @@ describe(module.filename || __filename, function() {
     it('creating collection', function () {
       assert.typeOf(Collection, 'function', 'Collection is defined');
 
-      class Developer extends Model {};
-      Developer.prototype.idAttribute = '_id';
-      Developer.prototype.entity = 'Developer';
+      class Developer extends Model.defaults({
+        idAttribute: '_id',
+        entity = 'Developer'
+      }) {}
       TEST.Developer = Developer;
 
       assert.ok(typeof TEST.Developer === 'function', 'Developer model successfully extended.');
 
-      class DeveloperCollection extends Collection {};
-      DeveloperCollection.prototype.url = TEST.url;
-      DeveloperCollection.prototype.model = TEST.Developer;
+      class DeveloperCollection extends Collection.defaults({
+        url: TEST.url,
+        model: TEST.Developer
+      }) {};
       TEST.DeveloperCollection = DeveloperCollection;
 
       assert.ok(typeof TEST.DeveloperCollection === 'function', 'Developer collection successfully extended.');

--- a/src/livedata/Collection.ts
+++ b/src/livedata/Collection.ts
@@ -99,6 +99,10 @@ export class Collection extends Backbone.Collection<Model> {
     this.init(models, options);
   }
 
+  public static defaults(properties: any, classProperties?: any): CollectionCtor {
+    return super['extend'](properties, classProperties);
+  }
+
   protected init(models?: any, options?: any) {
     options = options || {};
     this.store = options.store || this.store || (this.model ? this.model.prototype.store : null);

--- a/src/livedata/Collection.ts
+++ b/src/livedata/Collection.ts
@@ -36,13 +36,26 @@ import * as Q from 'q';
 import {ajax, sync} from './rest';
 
 /**
+ * prototype properties specified when subclassing using Collection.defaults().
+ */
+export interface CollectionProps {
+  model?: ModelCtor;
+  entity?: string;
+
+  options?: any;
+
+  url?: string | (() => string);
+  store?: Store;
+}
+
+/**
  * constructor function of Collection.
  */
 export interface CollectionCtor {
   /**
    * @see Collection#constructor
    */
-  new(models?: any, options?: any): Collection;
+  new(models?: Model[] | Object[], options?: any): Collection;
 }
 
 /**
@@ -89,7 +102,7 @@ export class Collection extends Backbone.Collection<Model> {
   public endpoint: SyncEndpoint;
   public channel: string;
 
-  public constructor(models?: any, options?: any) {
+  public constructor(models?: Model[] | Object[], options?: any) {
     super(models, options);
 
     if (this.url && this.url.charAt(this.url.length - 1) !== '/') {
@@ -99,11 +112,16 @@ export class Collection extends Backbone.Collection<Model> {
     this.init(models, options);
   }
 
-  public static defaults(properties: any, classProperties?: any): CollectionCtor {
-    return super['extend'](properties, classProperties);
+  /**
+   * sets up prototype properties when defining a Collection subclass.
+   * 
+   * @param {CollectionProps} properties of prototype to set.
+   */
+  public static defaults(properties: CollectionProps): CollectionCtor {
+    return super['extend'](properties);
   }
 
-  protected init(models?: any, options?: any) {
+  protected init(models?: Model[] | Object[], options?: any) {
     options = options || {};
     this.store = options.store || this.store || (this.model ? this.model.prototype.store : null);
     this.entity = options.entity || this.entity || (this.model ? this.model.prototype.entity : null);

--- a/src/livedata/Model.spec.ts
+++ b/src/livedata/Model.spec.ts
@@ -61,12 +61,14 @@ describe(module.filename || __filename, function() {
 
     it('creating model', function () {
       assert.typeOf(Model, 'function', 'Model is defined.');
-      class Person extends Model {};
-      Person.prototype.idAttribute = 'id';
-      Person.prototype.defaults = <any>{
-        bmi: 0.0
-      };
-      Person.prototype.entity = 'person';
+      class Person extends Model.defaults({
+        idAttribute: 'id',
+        defaults: {
+          bmi: 0.0
+        },
+        entity: 'person',
+
+      }) {};
       assert.typeOf(Person, 'function', 'person model could be extended.');
       assert.typeOf(new Person(), 'object', 'empty person model could be created.');
 

--- a/src/livedata/Model.ts
+++ b/src/livedata/Model.ts
@@ -91,6 +91,10 @@ export class Model/*<AttributesType extends Object>*/ extends Backbone.Model {
     this.init(attributes, options);
   }
 
+  public static defaults(properties: any, classProperties?: any): ModelCtor {
+    return super['extend'](properties, classProperties);
+  }
+
   protected init(attributes?: any, options?: any) {
     options = options || {};
 

--- a/src/livedata/Model.ts
+++ b/src/livedata/Model.ts
@@ -34,6 +34,27 @@ import {SyncEndpoint} from './SyncEndpoint';
 import {ajax, sync} from './rest';
 
 /**
+ * prototype properties specified when subclassing using Model.defaults().
+ */
+export interface ModelProps {
+  type?: {
+      container: string;
+      model: string;
+  } | string;
+  entity?: string;
+  tenancy?: 'USER' | 'ORGANIZATION' | 'SCOPE'; // com.mwaysolutions.gofer2.bikini.domain.LiveDataTenancy
+
+  idAttribute?: string;
+  aclAttribute?: string;
+
+  defaults?: any;
+
+  url?: string | (() => string);
+  urlRoot?: string | (() => string);
+  store?: Store;
+}
+
+/**
  * constructor function of Model.
  */
 export interface ModelCtor {
@@ -91,8 +112,13 @@ export class Model/*<AttributesType extends Object>*/ extends Backbone.Model {
     this.init(attributes, options);
   }
 
-  public static defaults(properties: any, classProperties?: any): ModelCtor {
-    return super['extend'](properties, classProperties);
+  /**
+   * sets up prototype properties when defining a Model subclass.
+   * 
+   * @param {ModelProps} properties of prototype to set.
+   */
+  public static defaults(properties: ModelProps): ModelCtor {
+    return super['extend'](properties);
   }
 
   protected init(attributes?: any, options?: any) {

--- a/src/livedata/SyncContext.spec.ts
+++ b/src/livedata/SyncContext.spec.ts
@@ -38,14 +38,14 @@ describe(module.filename || __filename, function() {
   this.timeout(60000);
 
   // prepare model/collection types
-  class TestModel extends Model {
-  }
-  TestModel.prototype.idAttribute = 'id';
-  TestModel.prototype.entity = 'approval';
+  class TestModel extends Model.defaults({
+    idAttribute: 'id',
+    entity: 'approval'
+  }) {}
 
-  class TestCollection extends Collection {
-  }
-  TestCollection.prototype.model = TestModel;
+  class TestCollection extends Collection.defaults({
+    model: TestModel
+  }) {}
 
   before(function() {
     return testServer.login.then((result) => {

--- a/src/livedata/SyncStore-offline.spec.ts
+++ b/src/livedata/SyncStore-offline.spec.ts
@@ -46,23 +46,24 @@ describe(module.filename || __filename, function() {
         useSocketNotify: false
       });
 
-      class ModelType extends Model {
+      class ModelType extends Model.defaults({
+        idAttribute: 'id',
+        entity: 'User',
+        store: store,
+        urlRoot: urls.resolveUrl('api/v1/user/', {
+          serverUrl: testServer.serverUrl,
+          application: 'relutionsdk'
+        }),
+        defaults: <any>{
+          username: 'admin',
+          password: 'admin'
+        }
+      }) {
         ajax() {
           debug.info('offline');
           return Q.reject(new Error('Not Online'));
         }
       }
-      ModelType.prototype.idAttribute = 'id';
-      ModelType.prototype.entity = 'User';
-      ModelType.prototype.store = store;
-      ModelType.prototype.urlRoot =  urls.resolveUrl('api/v1/user/', {
-        serverUrl: testServer.serverUrl,
-        application: 'relutionsdk'
-      });
-      ModelType.prototype.defaults = <any>{
-        username: 'admin',
-        password: 'admin'
-      };
       modelType = ModelType;
 
       model = new modelType({ id: '12312' });

--- a/src/livedata/SyncStore-sync-model-to-server.spec.ts
+++ b/src/livedata/SyncStore-sync-model-to-server.spec.ts
@@ -46,15 +46,15 @@ describe(module.filename || __filename, function() {
         useSocketNotify: false
       });
 
-      class ModelType extends Model {
-      }
-      ModelType.prototype.idAttribute = 'id';
-      ModelType.prototype.entity = 'User';
-      ModelType.prototype.store = store;
-      ModelType.prototype.urlRoot = urls.resolveUrl('api/v1/user/', {
-        serverUrl: testServer.serverUrl,
-        application: 'relutionsdk'
-      });
+      class ModelType extends Model.defaults({
+        idAttribute: 'id',
+        entity: 'User',
+        store: store,
+        urlRoot: urls.resolveUrl('api/v1/user/', {
+          serverUrl: testServer.serveUrl,
+          application: 'relutionsdk'
+        })
+      }) {}
       modelType = ModelType;
       model = new modelType({id: '12312'});
       promise = Q(model.fetch()).thenResolve(model);

--- a/src/livedata/SyncStore-sync-model-to-server.spec.ts
+++ b/src/livedata/SyncStore-sync-model-to-server.spec.ts
@@ -51,10 +51,11 @@ describe(module.filename || __filename, function() {
         entity: 'User',
         store: store,
         urlRoot: urls.resolveUrl('api/v1/user/', {
-          serverUrl: testServer.serveUrl,
+          serverUrl: testServer.serverUrl,
           application: 'relutionsdk'
         })
       }) {}
+
       modelType = ModelType;
       model = new modelType({id: '12312'});
       promise = Q(model.fetch()).thenResolve(model);

--- a/src/livedata/SyncStore.spec.ts
+++ b/src/livedata/SyncStore.spec.ts
@@ -283,7 +283,7 @@ describe(module.filename || __filename, function() {
 
         ajax(options?: any) {
           // following simulates server reassigning ID value
-          return Model.prototype.ajax.apply(this, arguments).then((response: any) => {
+          return super.ajax.apply(this, arguments).then((response: any) => {
             if (this.id === oldId) {
               response._id = newId;
             } else if (this.id === newId) {

--- a/src/livedata/SyncStore.spec.ts
+++ b/src/livedata/SyncStore.spec.ts
@@ -153,11 +153,12 @@ describe(module.filename || __filename, function() {
 
     it('fetching data with new model', (done) => {
 
-      class TestModel2 extends Model {}
-      TestModel2.prototype.url = TEST.url;
-      TestModel2.prototype.idAttribute = '_id';
-      TestModel2.prototype.store = TEST.store;
-      TestModel2.prototype.entity = 'test';
+      class TestModel2 extends Model.defaults({
+        url: TEST.url,
+        idAttribute: '_id',
+        store: TEST.store,
+        entity: 'test'
+      }) {}
       TEST.TestModel2 = TestModel2;
 
       var data = { _id: TEST.id };
@@ -181,11 +182,12 @@ describe(module.filename || __filename, function() {
     }),
 
     it('fetching model with no id using callbacks', (done) => {
-      class TestModel3 extends Model {}
-      TestModel3.prototype.url = TEST.url;
-      TestModel3.prototype.idAttribute = '_id';
-      TestModel3.prototype.store = TEST.store;
-      TestModel3.prototype.entity = 'test';
+      class TestModel3 extends Model.defaults({
+        url: TEST.url,
+        idAttribute: '_id',
+        store: TEST.store,
+        entity: 'test'
+      }) {}
       TEST.TestModel3 = TestModel3;
 
       var model = new TEST.TestModel3({});
@@ -200,11 +202,12 @@ describe(module.filename || __filename, function() {
     }),
 
     it('fetching model with empty-string id using promises', (done) => {
-      class TestModel4 extends Model {}
-      TestModel4.prototype.url = TEST.url;
-      TestModel4.prototype.idAttribute = '_id';
-      TestModel4.prototype.store = TEST.store;
-      TestModel4.prototype.entity =  'test';
+      class TestModel4 extends Model.defaults({
+        url: TEST.url,
+        idAttribute: '_id',
+        store: TEST.store,
+        entity: 'test'
+      }) {}
       TEST.TestModel4 = TestModel4;
 
       var model = new TEST.TestModel4({
@@ -267,7 +270,12 @@ describe(module.filename || __filename, function() {
       var oldId = model.id;
       var newId = '4711-' + oldId;
 
-      class TestModel5 extends Model {
+      class TestModel5 extends Model.defaults({
+        url: TEST.url,
+        idAttribute: '_id',
+        store: TEST.store,
+        entity: 'test'
+      }) {
         constructor(attrs: any) {
           super(attrs);
           this.ajax = this.ajax.bind(this);
@@ -285,10 +293,6 @@ describe(module.filename || __filename, function() {
           });
         }
       }
-      TestModel5.prototype.url = TEST.url;
-      TestModel5.prototype.idAttribute = '_id';
-      TestModel5.prototype.store = TEST.store;
-      TestModel5.prototype.entity = 'test';
 
       var testModel = new TestModel5(model.attributes);
 

--- a/src/livedata/SyncStore.spec.ts
+++ b/src/livedata/SyncStore.spec.ts
@@ -75,9 +75,10 @@ describe(module.filename || __filename, function() {
     it('creating collection', () => {
       assert.isFunction(Collection, 'Collection is defined');
 
-      class TestModel extends Model {}
-      TestModel.prototype.idAttribute = '_id';
-      TestModel.prototype.entity = 'test';
+      class TestModel extends Model.defaults({
+        idAttribute: '_id',
+        entity: 'test'
+      }) {}
       TEST.TestModel = TestModel;
 
       assert.isFunction(TEST.TestModel, 'TestModel model successfully extended.');
@@ -87,15 +88,16 @@ describe(module.filename || __filename, function() {
         application: 'relutionsdk'
       });
 
-      class TestsModelCollection extends Collection {}
-      TestsModelCollection.prototype.model = TEST.TestModel;
-      TestsModelCollection.prototype.url = TEST.url;
-      TestsModelCollection.prototype.store = TEST.store;
-      TestsModelCollection.prototype.options = {
-        sort: { sureName: 1 },
-        fields: { USERNAME: 1, sureName: 1, firstName: 1, age: 1 },
-        query: { age: { $gte: 25 } }
-      };
+      class TestsModelCollection extends Collection.defaults({
+        model: TEST.TestModel,
+        url: TEST.url,
+        store: TEST.store,
+        options: {
+          sort: { sureName: 1 },
+          fields: { USERNAME: 1, sureName: 1, firstName: 1, age: 1 },
+          query: { age: { $gte: 25 } }
+        }
+      }) {}
       TEST.TestsModelCollection = TestsModelCollection;
 
       assert.isFunction(TEST.TestsModelCollection, 'Test collection successfully extended.');

--- a/src/livedata/WebSqlStore.spec.ts
+++ b/src/livedata/WebSqlStore.spec.ts
@@ -265,7 +265,7 @@ describe(module.filename || __filename, function() {
         entity: 'test'
       }) {}
       TEST.TestModel2 = TestModel2;
-
+      
       TEST.Tests2 = new Collection(undefined, {
         model: TEST.TestModel2,
         store: TEST.store

--- a/src/livedata/WebSqlStore.spec.ts
+++ b/src/livedata/WebSqlStore.spec.ts
@@ -70,16 +70,18 @@ describe(module.filename || __filename, function() {
 
     it('simple websql store', function (done) {
 
-      class SimpleModel extends Model {}
-      SimpleModel.prototype.idAttribute = 'key';
+      class SimpleModel extends Model.defaults({
+        idAttribute: 'key'
+      }) {}
       TEST.SimpleModel = SimpleModel;
 
       assert.typeOf(TEST.SimpleModel, 'function', 'SimpleModel model successfully extended.');
 
-      class SimpleModelCollection extends Collection {}
-      SimpleModelCollection.prototype.model = TEST.SimpleModel;
-      SimpleModelCollection.prototype.store = new WebSqlStore();
-      SimpleModelCollection.prototype.entity = 'test';
+      class SimpleModelCollection extends Collection.defaults({
+        model: TEST.SimpleModel,
+        store: new WebSqlStore(),
+        entity: 'test'
+      }) {}
       TEST.SimpleModelCollection = SimpleModelCollection;
 
       assert.typeOf(TEST.SimpleModelCollection, 'function', 'Simple collection successfully extended.');
@@ -111,16 +113,18 @@ describe(module.filename || __filename, function() {
 
       assert.typeOf(Collection, 'function', 'Collection is defined');
 
-      class TestModel extends Model {}
-      TestModel.prototype.idAttribute = 'key';
-      TestModel.prototype.entity = 'test';
+      class TestModel extends Model.defaults({
+        idAttribute: 'key',
+        entity: 'test'
+      }) {}
       TEST.TestModel = TestModel;
 
       assert.typeOf(TEST.TestModel, 'function', 'TestModel model successfully extended.');
 
-      class TestModelCollection extends Collection {}
-      TestModelCollection.prototype.model = TEST.TestModel;
-      TestModelCollection.prototype.store = TEST.store;
+      class TestModelCollection extends Collection.defaults({
+        model: TEST.TestModel,
+        store: TEST.store
+      }) {}
       TEST.TestModelCollection = TestModelCollection;
 
       assert.typeOf(TEST.TestModelCollection, 'function', 'Test collection successfully extended.');
@@ -182,10 +186,11 @@ describe(module.filename || __filename, function() {
 
     it('fetching data with new model', function (done) {
 
-      class TestModel2 extends Model {}
-      TestModel2.prototype.idAttribute = 'key';
-      TestModel2.prototype.store = TEST.store;
-      TestModel2.prototype.entity = 'test';
+      class TestModel2 extends Model.defaults({
+        idAttribute: 'key',
+        store: TEST.store,
+        entity: 'test'
+      }) {}
       TEST.TestModel2 = TestModel2;
 
       var model = new TEST.TestModel2({
@@ -254,10 +259,11 @@ describe(module.filename || __filename, function() {
       // recreate store type to drop schema information
       TEST.store = new WebSqlStore(undefined);
 
-      class TestModel2 extends Model {}
-      TestModel2.prototype.idAttribute = 'key';
-      TestModel2.prototype.store = TEST.store;
-      TestModel2.prototype.entity = 'test';
+      class TestModel2 extends Model.defaults({
+        idAttribute: 'key',
+        store: TEST.store,
+        entity: 'test'
+      }) {}
       TEST.TestModel2 = TestModel2;
 
       TEST.Tests2 = new Collection(undefined, {


### PR DESCRIPTION
This allows new syntax for setting stuff such as the idAttribute when subclassing models and/or collections.

For example:
```javascript
  class TestModel extends Model.defaults({
    idAttribute: 'id',
    entity: 'approval'
  }) {
    // ...
  }

  class TestCollection extends Collection.defaults({
    model: TestModel
  }) {
    // ...
  }
```