### PR TITLE
Store factory methods

### DIFF
--- a/src/livedata/Collection.ts
+++ b/src/livedata/Collection.ts
@@ -51,12 +51,22 @@ export interface CollectionProps {
 /**
  * constructor function of Collection.
  */
-export interface CollectionCtor {
+export interface CollectionCtorT<CollectionType extends Collection, ModelType extends Model, OptionsType> {
+  /**
+   * prototype of constructor function.
+   */
+  prototype: CollectionType;
+
   /**
    * @see Collection#constructor
    */
-  new(models?: Model[] | Object[], options?: any): Collection;
+  new(models?: ModelType[] | Object[], options?: any): CollectionType;
 }
+
+/**
+ * constructor function of Collection.
+ */
+export type CollectionCtor = CollectionCtorT<Collection, Model, any>;
 
 /**
  * tests whether a given object is a Collection.

--- a/src/livedata/Model.ts
+++ b/src/livedata/Model.ts
@@ -57,12 +57,22 @@ export interface ModelProps {
 /**
  * constructor function of Model.
  */
-export interface ModelCtor {
+export interface ModelCtorT<ModelType extends Model, AttributesType, OptionsType> {
+  /**
+   * prototype of constructor function.
+   */
+  prototype: ModelType;
+
   /**
    * @see Model#constructor
    */
-  new(attributes?: any, options?: any): Model;
+  new(attributes?: AttributesType, options?: OptionsType): ModelType;
 }
+
+/**
+ * constructor function of Model.
+ */
+export type ModelCtor = ModelCtorT<Model, any, any>;
 
 /**
  * tests whether a given object is a Model.

--- a/src/livedata/Store.ts
+++ b/src/livedata/Store.ts
@@ -27,9 +27,8 @@ import * as _ from 'lodash';
 import * as Q from 'q';
 import * as diag from '../core/diag';
 
-import {Model} from './Model';
-import {Collection} from './Collection';
-import {CollectionCtor} from "./Collection";
+import {Model, ModelCtor, ModelCtorT, ModelProps, isModel} from './Model';
+import {Collection, CollectionCtor, CollectionCtorT, CollectionProps, isCollection} from './Collection';
 
 /**
  * constructor function of Store.
@@ -71,6 +70,30 @@ export class Store {
   // following are store-specific options, defaults stored in prototype at end of this file
   protected name: string;
 
+  /**
+   * stores Model and Collection constructors by entity name.
+   * 
+   * @see Store#makeModel
+   * @see Store#makeCollection
+   */
+  private implementations: _.Dictionary<{
+    /**
+     * subclassed Model constructor.
+     * 
+     * @see Store#extendModel
+     */
+    modelCtor: any,
+
+    /**
+     * subclassed Collection constructor.
+     * 
+     * @see Store#extendCollection
+     */
+    collectionCtor?: any
+  }> = {
+    // initially empty
+  };
+
   protected entities: any;
   public endpoints: any;
 
@@ -85,12 +108,160 @@ export class Store {
     // nothing to do
   }
 
+  /**
+   * factory method creating new Model instance bound to this Store.
+   * 
+   * @param  modelType to instantiate.
+   * @param  attributes of new instance.
+   * @param  options at creation time.
+   * @return new Model instance.
+   * 
+   * @see Store#createCollection
+   */
+  public createModel<ModelType extends Model, AttributesType, OptionsType>(modelType: ModelCtorT<ModelType, AttributesType, OptionsType>, attributes?: AttributesType, options?: OptionsType): ModelType {
+    return new (this.extendModel(modelType))(attributes, options);
+  }
+
+  /**
+   * factory method creating new Collection instance bound to this Store.
+   * 
+   * @param  collectionType to instantiate.
+   * @param  models of new instance.
+   * @param  options at creation time.
+   * @return new Collection instance.
+   * 
+   * @see Store#createModel
+   */
+  public createCollection<CollectionType extends Collection, ModelType extends Model, OptionsType>(collectionType: CollectionCtorT<CollectionType, ModelType, OptionsType>, models?: ModelType[] | Object[], options?: any): CollectionType {
+    return new (this.extendCollection(collectionType))(models, options);
+  }
+
+  /**
+   * additional initialization of Model instance.
+   * 
+   * @see Store#initCollection
+   *
+   * @internal API only to be called by Model constructor.
+   */
   initModel(model: Model, options?: any): void {
     // may be overwritten
   }
 
+  /**
+   * additional initialization of Collection instance.
+   * 
+   * @see Store#initModel
+   * 
+   * @internal API only to be called by Collection constructor.
+   */
   initCollection(collection: Collection, options?: any): void {
     // may be overwritten
+  }
+
+  /**
+   * subclasses a Model type such that it is linked to this Store.
+   * 
+   * @param modelType to subclass.
+   * @return subclassed Model implementation.
+   * 
+   * @see Store#createModel
+   * @see Store#defaultsModel
+   * @see Store#extendCollection
+   * 
+   * @internal API only to be called by Store#createModel.
+   */
+  private extendModel<ModelType extends Model, AttributesType, OptionsType>(modelType: ModelCtorT<ModelType, AttributesType, OptionsType>): ModelCtorT<ModelType, AttributesType, OptionsType> {
+    diag.debug.assert(() => isModel(modelType.prototype));
+    const entity = modelType.prototype.entity;
+    let implementation = this.implementations[entity];
+    if (implementation && implementation.modelCtor && implementation.modelCtor.prototype.__proto__.constructor === modelType) {
+      diag.debug.assert(implementation.modelCtor.prototype.store === this);
+    } else {
+      if (implementation && implementation.modelCtor) {
+        diag.debug.warn('redefinition of model ' + entity + ' might not work as expected as existing collections remain bound to previous model type!');
+      }
+      // collectionType is reset so that newly created collections get bound to new model implementation
+      this.implementations[entity] = implementation = {
+        modelCtor: modelType['extend'](this.defaultsModel(modelType))
+      };
+    }
+    diag.debug.assert(() => isModel(implementation.modelCtor.prototype));
+    return implementation.modelCtor;
+  }
+
+  /**
+   * subclasses a Collection type such that it is linked to this Store.
+   * 
+   * @param collectionType to subclass.
+   * @return subclassed Collection implementation.
+   * 
+   * @see Store#createCollection
+   * @see Store#defaultsCollection
+   * @see Store#extendModel
+   * 
+   * @internal API only to be called by Store#createCollection.
+   */
+  private extendCollection<CollectionType extends Collection, ModelType extends Model, OptionsType>(collectionType: CollectionCtorT<CollectionType, ModelType, OptionsType>): CollectionCtorT<CollectionType, ModelType, OptionsType> {
+    diag.debug.assert(() => isCollection(collectionType.prototype));
+    const modelType = this.extendModel(collectionType.prototype.model);
+    const entity = modelType.prototype.entity;
+    let implementation = this.implementations[entity];
+    diag.debug.assert(implementation && implementation.modelCtor === modelType);
+    if (implementation.collectionCtor && implementation.collectionCtor.prototype.__proto__.constructor === collectionType) {
+      diag.debug.assert(implementation.collectionCtor.prototype.store === this);
+    } else {
+      if (implementation && implementation.collectionCtor) {
+        diag.debug.warn('redefinition of collection ' + entity + ' might not work as expected as existing collections might exist!');
+      }
+      implementation.collectionCtor = collectionType['extend'](this.defaultsCollection(collectionType, modelType));
+    }
+    diag.debug.assert(() => isCollection(implementation.collectionCtor.prototype));
+    return implementation.collectionCtor;
+  }
+
+  /**
+   * defines prototype properties used for a given Model type.
+   * 
+   * @param modelType being subclassed.
+   * @return prototype properties of Model.
+   * 
+   * @see Store#defaultsCollection
+   */
+  protected defaultsModel<ModelType extends Model, AttributesType, OptionsType>(modelType: ModelCtorT<ModelType, AttributesType, OptionsType>): ModelProps {
+    // may be overwritten
+    return {
+      urlRoot: this.resolveUrl(<string>_.result(modelType.prototype, 'urlRoot')),
+      store: this
+    };
+  };
+
+  /**
+   * defines prototype properties used for a given Collection type.
+   * 
+   * @param collectionType being subclassed.
+   * @param modelType that was subclassed already, do not apply Store#extendModel on it!
+   * @return prototype properties of Collection.
+   * 
+   * @see Store#defaultsModel
+   */
+  protected defaultsCollection<CollectionType extends Collection, ModelType extends Model, OptionsType, AttributesType, ModelOptionsType>(collectionType: CollectionCtorT<CollectionType, ModelType, OptionsType>, modelType: ModelCtorT<ModelType, AttributesType, ModelOptionsType>): CollectionProps {
+    // may be overwritten
+    return {
+      model: modelType,
+      url: modelType.prototype.urlRoot,
+      store: this
+    };
+  }
+
+  /**
+   * may be overwritten to resolve relative URLs against the actual server.
+   * 
+   * @param url to resolve.
+   * @return resolved url.
+   */
+  protected resolveUrl(url: string) {
+    // may be overwritten
+    return url;
   }
 
   sync(method: string, model: Model | Collection, options?: any): Q.Promise<any> {

--- a/src/livedata/SyncStore.spec.ts
+++ b/src/livedata/SyncStore.spec.ts
@@ -29,7 +29,6 @@ import {Model} from './Model';
 import {Collection} from './Collection';
 import {SyncStore} from './SyncStore';
 
-import * as urls from '../web/urls';
 import {testServer} from '../web/http.spec';
 
 function backbone_error(done: Function) {
@@ -64,6 +63,7 @@ describe(module.filename || __filename, function() {
       assert.isFunction(SyncStore, 'SyncStore is defined');
 
       TEST.store = new SyncStore({
+        application: 'relutionsdk',
         useLocalStore: true,
         useSocketNotify: false
       });
@@ -75,15 +75,12 @@ describe(module.filename || __filename, function() {
     it('creating collection', () => {
       assert.isFunction(Collection, 'Collection is defined');
 
-      TEST.url = urls.resolveUrl('api/v1/test/', {
-        serverUrl: testServer.serverUrl,
-        application: 'relutionsdk'
-      });
+      TEST.urlRoot = 'api/v1/test/';
 
       class TestModel extends Model.defaults({
         idAttribute: '_id',
         entity: 'test',
-        urlRoot: TEST.url
+        urlRoot: TEST.urlRoot
       }) {}
       TEST.TestModel = TestModel;
 
@@ -109,9 +106,9 @@ describe(module.filename || __filename, function() {
 
       var url = TEST.Tests.getUrl();
 
-      assert.ok(url !== TEST.url, 'The base url has been extended.');
+      assert.ok(url !== TEST.urlRoot, 'The base url has been extended.');
 
-      assert.equal(url.indexOf(TEST.url), 0, 'the new url starts with the set url.');
+      assert.ok(url.indexOf(TEST.urlRoot) > 0, 'the new url has the set url as a part.');
 
       assert.ok(url.indexOf('query=') > 0, 'query is part of the url.');
 
@@ -153,15 +150,14 @@ describe(module.filename || __filename, function() {
     it('fetching data with new model', (done) => {
 
       class TestModel2 extends Model.defaults({
-        url: TEST.url,
+        urlRoot: TEST.urlRoot,
         idAttribute: '_id',
-        store: TEST.store,
         entity: 'test'
       }) {}
       TEST.TestModel2 = TestModel2;
 
       var data = { _id: TEST.id };
-      var model = new TEST.TestModel2(data);
+      var model = (<SyncStore>TEST.store).createModel(TestModel2, data);
 
       assert.isObject(model, 'new model created');
 
@@ -182,14 +178,13 @@ describe(module.filename || __filename, function() {
 
     it('fetching model with no id using callbacks', (done) => {
       class TestModel3 extends Model.defaults({
-        url: TEST.url,
+        urlRoot: TEST.urlRoot,
         idAttribute: '_id',
-        store: TEST.store,
         entity: 'test'
       }) {}
       TEST.TestModel3 = TestModel3;
 
-      var model = new TEST.TestModel3({});
+      var model = (<SyncStore>TEST.store).createModel(TestModel3, {});
       model.fetch({
         success: function(model2: Model) {
           backbone_error(done)(model2, new Error('this should have failed!'));
@@ -202,14 +197,13 @@ describe(module.filename || __filename, function() {
 
     it('fetching model with empty-string id using promises', (done) => {
       class TestModel4 extends Model.defaults({
-        url: TEST.url,
+        urlRoot: TEST.urlRoot,
         idAttribute: '_id',
-        store: TEST.store,
         entity: 'test'
       }) {}
       TEST.TestModel4 = TestModel4;
 
-      var model = new TEST.TestModel4({
+      var model = (<SyncStore>TEST.store).createModel(TestModel4, {
         _id: ''
       });
       model.fetch().then(function() {
@@ -270,9 +264,8 @@ describe(module.filename || __filename, function() {
       var newId = '4711-' + oldId;
 
       class TestModel5 extends Model.defaults({
-        url: TEST.url,
+        urlRoot: TEST.urlRoot,
         idAttribute: '_id',
-        store: TEST.store,
         entity: 'test'
       }) {
         constructor(attrs: any) {
@@ -293,7 +286,7 @@ describe(module.filename || __filename, function() {
         }
       }
 
-      var testModel = new TestModel5(model.attributes);
+      var testModel = (<SyncStore>TEST.store).createModel(TestModel5, model.attributes);
 
       var options = {
         wait: true
@@ -306,7 +299,7 @@ describe(module.filename || __filename, function() {
         assert.isUndefined(TEST.Tests.get(oldId), 'model is missing in collection by old id.');
       }).then(function() {
         // reverts local changes
-        options['url'] = TEST.url + oldId; // must fix up URL as we hacked it
+        options['url'] = testModel.urlRoot + oldId; // must fix up URL as we hacked it
         return testModel.save(undefined, options).then(function() {
           assert.ok(testModel.id, 'record has an id.');
           assert.equal(testModel.id, oldId, 'record has new id.');

--- a/src/livedata/SyncStore.spec.ts
+++ b/src/livedata/SyncStore.spec.ts
@@ -75,23 +75,22 @@ describe(module.filename || __filename, function() {
     it('creating collection', () => {
       assert.isFunction(Collection, 'Collection is defined');
 
-      class TestModel extends Model.defaults({
-        idAttribute: '_id',
-        entity: 'test'
-      }) {}
-      TEST.TestModel = TestModel;
-
-      assert.isFunction(TEST.TestModel, 'TestModel model successfully extended.');
-
       TEST.url = urls.resolveUrl('api/v1/test/', {
         serverUrl: testServer.serverUrl,
         application: 'relutionsdk'
       });
 
+      class TestModel extends Model.defaults({
+        idAttribute: '_id',
+        entity: 'test',
+        urlRoot: TEST.url
+      }) {}
+      TEST.TestModel = TestModel;
+
+      assert.isFunction(TEST.TestModel, 'TestModel model successfully extended.');
+
       class TestsModelCollection extends Collection.defaults({
         model: TEST.TestModel,
-        url: TEST.url,
-        store: TEST.store,
         options: {
           sort: { sureName: 1 },
           fields: { USERNAME: 1, sureName: 1, firstName: 1, age: 1 },
@@ -102,7 +101,7 @@ describe(module.filename || __filename, function() {
 
       assert.isFunction(TEST.TestsModelCollection, 'Test collection successfully extended.');
 
-      TEST.Tests = new TEST.TestsModelCollection();
+      TEST.Tests = (<SyncStore>TEST.store).createCollection(TestsModelCollection);
 
       assert.isObject(TEST.Tests, 'Test collection successfully created.');
 
@@ -335,6 +334,7 @@ describe(module.filename || __filename, function() {
     }),
 
     it('cleanup records', (done) => {
+      assert.equal(TEST.Tests.models.length, TEST.Tests.length, 'backbone and array report the same length');
       if (TEST.Tests.length === 0) {
         done();
       } else {
@@ -358,6 +358,7 @@ describe(module.filename || __filename, function() {
             });
           }
         });
+        assert.equal(count, TEST.Tests.length, 'destroy executes asynchronously');
       }
     })
 

--- a/src/livedata/SyncStore.ts
+++ b/src/livedata/SyncStore.ts
@@ -215,10 +215,20 @@ export class SyncStore extends Store {
     }
   }
 
+  /**
+   * @inheritdoc
+   * 
+   * @internal API only to be called by Model constructor.
+   */
   initModel(model: Model): void {
     model.endpoint = this.initEndpoint(model, <ModelCtor>model.constructor);
   }
 
+  /**
+   * @inheritdoc
+   * 
+   * @internal API only to be called by Collection constructor.
+   */
   initCollection(collection: Collection): void {
     collection.endpoint = this.initEndpoint(collection, collection.model);
   }

--- a/src/livedata/SyncStore.ts
+++ b/src/livedata/SyncStore.ts
@@ -99,6 +99,10 @@ export class SyncStore extends Store {
    */
   protected serverUrl: string;
   /**
+   * application part used to resolve URLs may optionally be set using constructor options.
+   */
+  protected application: string;
+  /**
    * identity or user associated with this store.
    *
    * The ajax method will simulate an offline timeout when the user identity is changed. This is
@@ -144,6 +148,16 @@ export class SyncStore extends Store {
       diag.debug.warning('Socket.IO not present !!');
       this.useSocketNotify = false;
     }
+  }
+
+  /**
+   * overwritten to resolve relative URLs against the SyncStore#serverUrl.
+   */
+  protected resolveUrl(url: string) {
+    return web.resolveUrl(url, {
+      serverUrl: this.serverUrl,
+      application: this.application
+    });
   }
 
   /**


### PR DESCRIPTION
This implements Store.createModel(Model) and Store.createCollection(Collection) factory methods.

We now can do:

```javascript
// no store set below:
class MyModel...;
class MyCollection extends Collection.defaults({
   model: MyModel
}) {
  // ...
}

// and later create the store
var store = new SyncStore();
var collection = store.createCollection(MyCollection);
```