### PR TITLE
introduces Relution.web.getOnlineStatus() returning Server version information

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -37,6 +37,7 @@ export default [
   // web
   require('./web/http.spec'),
   require('./web/urls.spec'),
+  require('./web/online.spec'),
   require('./web/offline.spec'),
 
   // model

--- a/src/security/server.ts
+++ b/src/security/server.ts
@@ -31,6 +31,8 @@ import * as diag from '../core/diag';
 import * as auth from './auth';
 import * as roles from './roles';
 
+import * as online from '../web/online';
+
 /**
  * per-server state management.
  *
@@ -83,12 +85,14 @@ export class Server {
     /**
      * copy of credentials required for reestablishing the session when it timed out, for example.
      */
-    credentials: auth.Credentials
+    credentials: auth.Credentials,
+    serverInfos: online.ServerInformation
   } = {
     authorization: auth.ANONYMOUS_AUTHORIZATION,
     organization: null,
     user: null,
-    credentials: null
+    credentials: null,
+    serverInfos: null
   };
 
   /**
@@ -156,6 +160,17 @@ export class Server {
       this.state.credentials = auth.freezeCredentials(auth.cloneCredentials(credentials));
     } else {
       this.state.credentials = null;
+    }
+  }
+
+  get serverInfos(): online.ServerInformation {
+    return this.state.serverInfos;
+  }
+  set serverInfos(serverInfos: online.ServerInformation) {
+    if (serverInfos) {
+      this.state.serverInfos = online.freezeServerInformation(serverInfos);
+    } else {
+      this.state.serverInfos = null;
     }
   }
 

--- a/src/web/http.spec.ts
+++ b/src/web/http.spec.ts
@@ -27,6 +27,7 @@ import * as Q from 'q';
 import * as assert from 'assert';
 import * as web from './index';
 import * as offline from './offline';
+import * as urls from './urls';
 import {debug} from '../core/diag';
 
 import * as security from '../security';
@@ -41,7 +42,7 @@ export class TestServer {
   }
 
   public get serverUrl(): string {
-    return this.resetProperty('serverUrl', offline.localStorage().getItem('test.serverUrl') || 'http://localhost:8080');
+    return this.resetProperty('serverUrl', urls.resolveServer(offline.localStorage().getItem('test.serverUrl') || 'http://localhost:8080'));
   }
 
   public get credentials(): security.LoginObject {

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -26,3 +26,5 @@
 export * from './urls';
 export * from './http';
 export * from './verb';
+export * from './online';
+export * from './offline';

--- a/src/web/online.spec.ts
+++ b/src/web/online.spec.ts
@@ -1,0 +1,68 @@
+/*
+ * @file web/online.spec.ts
+ * Relution SDK
+ *
+ * Created by Thomas Beckmann on 14.10.2016
+ * Copyright 2016 M-Way Solutions GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @module web
+ */
+/** */
+
+import * as _ from 'lodash';
+
+import * as online from './online';
+import * as verb from './verb';
+import * as http from './http';
+
+import * as assert from 'assert';
+
+import { testServer } from './http.spec';
+
+describe(module.filename || __filename, function() {
+  return [
+
+    it('online status', () => {
+      return verb.get({
+        serverUrl: testServer.serverUrl,
+        url: '/gofer/gui/index.html'
+      }).then((resp) => {
+        assert(resp);
+        return online.getOnlineStatus(testServer.serverUrl);
+      }).then((serverInfos) => {
+        assert(!!serverInfos);
+        assert(_.isString(serverInfos.version));
+        assert(_.isString(serverInfos.description));
+        return serverInfos;
+      });
+    }),
+
+    it('online status no answer', () => {
+      return verb.get('http://127.0.0.1:32767/does-not-exist').then((resp) => {
+        throw new assert.AssertionError('timeout expected');
+      }, (error: http.HttpError) => {
+        assert(!error.statusCode, error.message || 'timeout expected');
+        return online.getOnlineStatus({
+          serverUrl: 'http://127.0.0.1:32767/'
+        });
+      }).then((serverInfos) => {
+        assert(!serverInfos);
+        return serverInfos;
+      });
+    })
+
+  ];
+});

--- a/src/web/online.ts
+++ b/src/web/online.ts
@@ -1,0 +1,72 @@
+/*
+ * @file web/online.ts
+ * Relution SDK
+ *
+ * Created by Thomas Beckmann on 14.10.2016
+ * Copyright 2016 M-Way Solutions GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @module web
+ */
+/** */
+
+import * as init from '../core/init';
+import * as server from '../security/server';
+
+/**
+ * version information of Relution server extracted from response header.
+ */
+export interface ServerInformation {
+  /**
+   * plain version number of Relution server.
+   *
+   * This is the value of the X-Relution-Version header: `3.56`, for example.
+   */
+  version?: string;
+  /**
+   * human readable full name of Relution server.
+   *
+   * This is the value of the X-Server header: `Relution/3.56 Enterprise (Wed Sep 28 11:16:00 CEST 2016)`, for example.
+   */
+  description?: string;
+}
+
+/**
+ * turns the object deeply immutable.
+ *
+ * @param serverInfos to freeze.
+ * @return {ServerInformation} serverInfos for convenience.
+ *
+ * @internal for library use only.
+ */
+export function freezeServerInformation(serverInfos: ServerInformation): ServerInformation {
+  return Object.freeze(serverInfos);
+}
+
+/**
+ * gets the [[ServerInformation]] of the last recent [[ajax]] request.
+ *
+ * @param serverUrlOrServerUrlOptions url of server or options object, omit to query the current server.
+ * @return information object when online, or falsy when offline.
+ */
+export function getOnlineStatus(serverUrlOrServerUrlOptions: string | init.ServerUrlOptions = init.initOptions.serverUrl): ServerInformation {
+  let serverUrl: string;
+  if (_.isString(serverUrlOrServerUrlOptions)) {
+    serverUrl = serverUrlOrServerUrlOptions;
+  } else if (serverUrlOrServerUrlOptions) {
+    serverUrl = serverUrlOrServerUrlOptions.serverUrl;
+  }
+  return server.Server.getInstance(serverUrl).serverInfos;
+}


### PR DESCRIPTION
This words as long as we are online only. The information is not stored for offline usage and it gets erased as soon as offline status is noticed.